### PR TITLE
cria CRUD para a entidade Campanhas com foco no GET de todas as campanhas

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { DatabaseModule } from './database/database.module';
 import { ConfigModule } from '@nestjs/config';
 import { MarcasModule } from './marcas/marcas.module';
 import { ProdutosModule } from './produtos/produtos.module';
+import { CampanhasModule } from './campanhas/campanhas.module';
 
 @Module({
   imports: [
@@ -12,6 +13,7 @@ import { ProdutosModule } from './produtos/produtos.module';
     DatabaseModule,
     MarcasModule,
     ProdutosModule,
+    CampanhasModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/campanhas/campanhas.controller.spec.ts
+++ b/src/campanhas/campanhas.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CampanhasController } from './campanhas.controller';
+import { CampanhasService } from './campanhas.service';
+
+describe('CampanhasController', () => {
+  let controller: CampanhasController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CampanhasController],
+      providers: [CampanhasService],
+    }).compile();
+
+    controller = module.get<CampanhasController>(CampanhasController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/campanhas/campanhas.controller.ts
+++ b/src/campanhas/campanhas.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { CampanhasService } from './campanhas.service';
+import { CreateCampanhaDto } from './dto/create-campanha.dto';
+import { UpdateCampanhaDto } from './dto/update-campanha.dto';
+
+@Controller('campanhas')
+export class CampanhasController {
+  constructor(private readonly campanhasService: CampanhasService) {}
+
+//  @Post()
+//  create(@Body() createCampanhaDto: CreateCampanhaDto) {
+//    return this.campanhasService.create(createCampanhaDto);
+//  }
+
+  @Get()
+  findAll() {
+    return this.campanhasService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.campanhasService.findOne(+id);
+  }
+
+//  @Patch(':id')
+//  update(@Param('id') id: string, @Body() updateCampanhaDto: UpdateCampanhaDto) {
+//    return this.campanhasService.update(+id, updateCampanhaDto);
+//  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.campanhasService.remove(+id);
+  }
+}

--- a/src/campanhas/campanhas.module.ts
+++ b/src/campanhas/campanhas.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { CampanhasService } from './campanhas.service';
+import { CampanhasController } from './campanhas.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Campanhas } from './entities/campanha.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Campanhas])],
+  controllers: [CampanhasController],
+  providers: [CampanhasService],
+})
+export class CampanhasModule {}

--- a/src/campanhas/campanhas.service.spec.ts
+++ b/src/campanhas/campanhas.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CampanhasService } from './campanhas.service';
+
+describe('CampanhasService', () => {
+  let service: CampanhasService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CampanhasService],
+    }).compile();
+
+    service = module.get<CampanhasService>(CampanhasService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/campanhas/campanhas.service.ts
+++ b/src/campanhas/campanhas.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { CreateCampanhaDto } from './dto/create-campanha.dto';
+import { UpdateCampanhaDto } from './dto/update-campanha.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Campanhas } from './entities/campanha.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class CampanhasService {
+  constructor(
+    @InjectRepository(Campanhas)
+    private campanhaRepository: Repository<Campanhas>,
+  ) {}
+
+//  create(createCampanhaDto: CreateCampanhaDto) {
+//    return 'This action adds a new campanha';
+//  }
+
+  findAll() {
+    return this.campanhaRepository.find();
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} campanha`;
+  }
+
+//  update(id: number, updateCampanhaDto: UpdateCampanhaDto) {
+//    return `This action updates a #${id} campanha`;
+//  }
+
+  remove(id: number) {
+    return `This action removes a #${id} campanha`;
+  }
+}

--- a/src/campanhas/dto/create-campanha.dto.ts
+++ b/src/campanhas/dto/create-campanha.dto.ts
@@ -1,0 +1,1 @@
+export class CreateCampanhaDto {}

--- a/src/campanhas/dto/update-campanha.dto.ts
+++ b/src/campanhas/dto/update-campanha.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateCampanhaDto } from './create-campanha.dto';
+
+export class UpdateCampanhaDto extends PartialType(CreateCampanhaDto) {}

--- a/src/campanhas/entities/campanha.entity.ts
+++ b/src/campanhas/entities/campanha.entity.ts
@@ -1,0 +1,16 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class Campanhas {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ length: 100 })
+  label: string;
+
+  @Column({ type: 'date' })
+  data_inicio: Date;
+
+  @Column({ type: 'date' })
+  data_fim: Date;
+}


### PR DESCRIPTION
rodei o comando `nest generate resource campanhas` e gerei um CRUD para a entidade Campanhas, semelhante ao que o Italo fez com Produtos e Marcas.

O GET /campanhas retorna todas as campanhas

